### PR TITLE
[FIX] README Code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ struct Filter: JSONCodable {
   let id: String
 }
 
-let jsonString = Filter(id: "foo").toJSON()
+let jsonString = try Filter(id: "foo").toJSON()
 ```
 
 or use `CodableFormat`:


### PR DESCRIPTION
Method `toJSON` can throw the call must be marked with `try`.