### PR TITLE
Change `String?` to `String` for throwing function

### DIFF
--- a/Sources/JSONCodable/JSONCodable.swift
+++ b/Sources/JSONCodable/JSONCodable.swift
@@ -5,8 +5,8 @@ import Foundation
 public protocol JSONEncodable: Encodable { }
 
 public extension JSONEncodable {
-  func toJSON(jsonEncoder: JSONEncoder = JSONEncoder()) throws -> String? {
-    try String(data: jsonEncoder.encode(self), encoding: .utf8)
+  func toJSON(jsonEncoder: JSONEncoder = JSONEncoder()) throws -> String {
+    try String(decoding: jsonEncoder.encode(self), as: UTF8.self)
   }
 }
 


### PR DESCRIPTION
`String` has an [initializer](https://developer.apple.com/documentation/swift/string/2907004-init) for decoding UTF8 that doesn't return an initializer from an already throwing method.